### PR TITLE
fix: replace deprecated `poetry lock`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ install: ## Install the poetry environment
 .PHONY: check
 check: ## Run code quality tools.
 	@echo "🚀 Checking Poetry lock file consistency with 'pyproject.toml': Running poetry lock --check"
-	@poetry lock --check
+	@poetry check --lock
 	@echo "🚀 Linting code: Running pre-commit"
 	@poetry run pre-commit run -a
 	@echo "🚀 Linting with ruff"

--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -8,7 +8,7 @@ install: ## Install the poetry environment and install the pre-commit hooks
 .PHONY: check
 check: ## Run code quality tools.
 	@echo "🚀 Checking Poetry lock file consistency with 'pyproject.toml': Running poetry lock --check"
-	@poetry lock --check
+	@poetry check --lock
 	@echo "🚀 Linting code: Running pre-commit"
 	@poetry run pre-commit run -a
 	@echo "🚀 Static type checking: Running mypy"


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [x] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests! (Not relevant)
-   [x] Documentation in `docs` is updated (Not relevant)

**Description of changes**

This minor change replaces the deprecated `poetry lock --check` with the new command `poetry check --lock`. 

This will resolve the following warning that currently appears when using `make check`. 

```bash
> make check
🚀 Checking Poetry lock file consistency with 'pyproject.toml': Running poetry lock --check
poetry lock --check is deprecated, use `poetry check --lock` instead.
poetry.lock is consistent with pyproject.toml.
...
```
