### PR TITLE
Trigger CI to run on "Ready for review"

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   quality:


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated

**Description of changes**
I find this useful, because if PR is WIP, then we'll mark it as draft, I don't want the CI tests to be triggered when it's on draft, which doesn't, but then when I press the button "ready for review" the ci test should run. 
Right now, dev should make "ANOTHER COMMIT" to trigger the ci, when a pr is moved from draft to ready to be reviewed