### PR TITLE
Use ruff over black in the root

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,14 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/psf/black
-    rev: "22.8.0"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.1.6"
     hooks:
-      - id: black
+      - id: ruff
+        args: [--exit-non-zero-on-fix, --config=pyproject.toml]
+        exclude: ^{{cookiecutter.project_name}}
+      - id: ruff-format
+        args: [--config=pyproject.toml]
         exclude: ^{{cookiecutter.project_name}}
 
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/cookiecutter_poetry/cli.py
+++ b/cookiecutter_poetry/cli.py
@@ -4,4 +4,4 @@ import os
 def main() -> None:
     cwd = os.path.dirname(__file__)
     package_dir = os.path.abspath(os.path.join(cwd, ".."))
-    os.system(f"cookiecutter {package_dir}")
+    os.system(f"cookiecutter {package_dir}")  # noqa: S605 | No injection, retrieving path in OS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,4 +118,4 @@ ignore = [
 ]
 
 [tool.ruff.per-file-ignores]
-"tests/*" = ["S101"]
+"tests/*" = ["S101", "S603"]


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [N/A] If there is a related issue, make sure it is linked to this PR.
- [N/A] If you've fixed a bug or added code that should be tested, add tests!
- [N/A] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->

Some issues we encountered in ruff were also encountered by @fpgmaas in this project, namely that with a nested project structure like this ruff picks up both `pyproject.toml` files and you get a "nested alternate groups are not allowed" error, see for instance https://github.com/astral-sh/ruff/issues/9381. This is solved by passing the `--config` flag so that ruff only looks at the `pyproject.toml` file in the root. I took the settings for ruff from [{{cookiecutter.project_name}}/.pre-commit-config.yaml](https://github.com/fpgmaas/cookiecutter-poetry/blob/main/%7B%7Bcookiecutter.project_name%7D%7D/.pre-commit-config.yaml)

/.pre-commit-config.yaml`.

For the two issues found by ruff, I made the following fixes:
- subprocess-without-shell-equals-true (S603): Ignored. Following [the documentation](https://docs.astral.sh/ruff/rules/subprocess-without-shell-equals-true/), this is prone to false positives. Even though the rule is called "subprocess-without-shell-equals-true", passing `shell=True` does not fix the hook.
- start-process-with-a-shell  (S605): Ignored. This is a problem if we receive user input but we derive a path here from the OS. As such, no security risk.