### PR TITLE
Bugfixes for EOF, whitespace, and prettier checks.

### DIFF
--- a/{{cookiecutter.project_name}}/.devcontainer/devcontainer.json
+++ b/{{cookiecutter.project_name}}/.devcontainer/devcontainer.json
@@ -14,10 +14,7 @@
     // Configure tool-specific properties.
     "customizations": {
         "vscode": {
-            "extensions": [
-                "ms-python.python",
-                "editorconfig.editorconfig",
-            ],
+            "extensions": ["ms-python.python", "editorconfig.editorconfig"],
             "settings": {
                 "python.testing.pytestArgs": ["tests"],
                 "python.testing.unittestEnabled": false,

--- a/{{cookiecutter.project_name}}/.github/actions/setup-poetry-env/action.yml
+++ b/{{cookiecutter.project_name}}/.github/actions/setup-poetry-env/action.yml
@@ -2,10 +2,10 @@ name: "setup-poetry-env"
 description: "Composite action to setup the Python and poetry environment."
 
 inputs:
-   python-version:
-     required: false
-     description: "The python version to use"
-     default: "3.11"
+  python-version:
+    required: false
+    description: "The python version to use"
+    default: "3.11"
 
 runs:
   using: "composite"

--- a/{{cookiecutter.project_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/main.yml
@@ -48,7 +48,6 @@ jobs:
 
       - name: Check typing
         run: poetry run mypy
-
 {% if cookiecutter.codecov == "y" %}
       - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11
         uses: codecov/codecov-action@v4

--- a/{{cookiecutter.project_name}}/.github/workflows/on-release-main.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/on-release-main.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  {% if cookiecutter.publish_to != "none" %}
+{%- if cookiecutter.publish_to != "none" %}
   publish:
     runs-on: ubuntu-latest
     steps:
@@ -39,8 +39,8 @@ jobs:
           RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
           {%- endraw -%}
           {%- endif %}
-  {% endif %}
-  {%- if cookiecutter.mkdocs == "y" %}
+{%- endif -%}
+{%- if cookiecutter.mkdocs == "y" %}
   deploy-docs:
     {%- if cookiecutter.publish_to != "none" %}
     needs: publish
@@ -55,4 +55,4 @@ jobs:
 
       - name: Deploy documentation
         run: poetry run mkdocs gh-deploy --force
-  {% endif %}
+{% endif %}

--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -35,26 +35,22 @@ The CI/CD pipeline will be triggered when you open a pull request, merge to main
 To finalize the set-up for publishing to PyPi or Artifactory, see [here](https://fpgmaas.github.io/cookiecutter-poetry/features/publishing/#set-up-for-pypi).
 For activating the automatic documentation with MkDocs, see [here](https://fpgmaas.github.io/cookiecutter-poetry/features/mkdocs/#enabling-the-documentation-on-github).
 To enable the code coverage reports, see [here](https://fpgmaas.github.io/cookiecutter-poetry/features/codecov/).
-
+{% if cookiecutter.publish_to == "pypi" %}
 ## Releasing a new version
-
-{% if cookiecutter.publish_to == "pypi" -%}
 
 - Create an API Token on [Pypi](https://pypi.org/).
 - Add the API Token to your projects secrets with the name `PYPI_TOKEN` by visiting [this page](https://github.com/{{cookiecutter.author_github_handle}}/{{cookiecutter.project_name}}/settings/secrets/actions/new).
 - Create a [new release](https://github.com/{{cookiecutter.author_github_handle}}/{{cookiecutter.project_name}}/releases/new) on Github.
 - Create a new tag in the form `*.*.*`.
-
-For more details, see [here](https://fpgmaas.github.io/cookiecutter-poetry/features/cicd/#how-to-trigger-a-release).
-{%- elif cookiecutter.publish_to == "artifactory" -%}
+- For more details, see [here](https://fpgmaas.github.io/cookiecutter-poetry/features/cicd/#how-to-trigger-a-release).
+{% elif cookiecutter.publish_to == "artifactory" %}
+## Releasing a new version
 
 - Add the `ARTIFACTORY_URL`, `ARTIFACTORY_USERNAME`, and `ARTIFACTORY_PASSWORD` to your projects secrets by visiting [this page](https://github.com/{{cookiecutter.author_github_handle}}/{{cookiecutter.project_name}}/settings/secrets/actions/new).
 - Create a [new release](https://github.com/{{cookiecutter.author_github_handle}}/{{cookiecutter.project_name}}/releases/new) on Github.
 - Create a new tag in the form `*.*.*`.
-
-For more details, see [here](https://fpgmaas.github.io/cookiecutter-poetry/features/cicd/#how-to-trigger-a-release).
-{%- endif %}
-
+- For more details, see [here](https://fpgmaas.github.io/cookiecutter-poetry/features/cicd/#how-to-trigger-a-release).
+{% endif %}
 ---
 
 Repository initiated with [fpgmaas/cookiecutter-poetry](https://github.com/fpgmaas/cookiecutter-poetry).

--- a/{{cookiecutter.project_name}}/mkdocs.yml
+++ b/{{cookiecutter.project_name}}/mkdocs.yml
@@ -15,9 +15,9 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-            setup_commands:
-                - import sys
-                - sys.path.append('../')
+          setup_commands:
+            - import sys
+            - sys.path.append('../')
 theme:
   name: material
   feature:


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.

**Description of changes**

When running CI, we observe the following errors due to linting.

```
🚀 Checking Poetry lock file consistency with 'pyproject.toml': Running poetry lock --check
All set!
🚀 Linting code: Running pre-commit
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/astral-sh/ruff-pre-commit.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@3.0.3.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/astral-sh/ruff-pre-commit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
check toml...............................................................Passed
check yaml...............................................................Passed
fix end of files.........................................................Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook

Fixing LICENSE

trim trailing whitespace.................................................Failed
- hook id: trailing-whitespace
- exit code: 1
- files were modified by this hook

Fixing .github/workflows/on-release-main.yml

ruff.....................................................................Passed
ruff-format..............................................................Passed
prettier.................................................................Failed
- hook id: prettier
- files were modified by this hook

README.md
.github/actions/setup-poetry-env/action.yml
.github/workflows/main.yml
.github/workflows/on-release-main.yml
mkdocs.yml

make: *** [Makefile:13: check] Error 1
Error: Process completed with exit code 2.
```

This PR applies some formatting changes across the repo such that these tests are now passed in the initial commit. This appears to be related to https://github.com/fpgmaas/cookiecutter-poetry/issues/96 and https://github.com/fpgmaas/cookiecutter-poetry/pull/97.

Changes include:
- Reformatting the extensions item in `{{cookiecutter.project_name}}/.devcontainer/devcontainer.json` to be on a single line.
- Un-indenting lines 5 through 8 in `{{cookiecutter.project_name}}/.github/actions/setup-poetry-env/action.yml`.
- Removing a newline on line 51 in `{{cookiecutter.project_name}}/.github/workflows/main.yml`.
- Jinja templating changes for lstrip and trim blocks in `{{cookiecutter.project_name}}/.github/workflows/on-release-main.yml`.
- Jinja templating changes for lstrip and trim blocks in `{{cookiecutter.project_name}}/README.md`.
- Un-indenting in `{{cookiecutter.project_name}}/mkdocs.yml`.

These changes should not change any user behaviour apart from allowing the CI to pass first time without any user modification.
