### PR TITLE
fix: run tests with code coverage only if enabled

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/main.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/main.yml
@@ -44,7 +44,11 @@ jobs:
           python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
 
       - name: Run tests
+{%- if cookiecutter.codecov == "y" %}
         run: poetry run pytest tests --cov --cov-config=pyproject.toml --cov-report=xml
+{%- else %}
+        run: poetry run pytest tests
+{%- endif %}
 
       - name: Check typing
         run: poetry run {{ cookiecutter.typechecking }}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated

fix #128

Added simple if statements so that the tests with code coverage only get run if they code coverage is enabled.
No docs necessary IMHO
Sorry, I do not know how to write a test case for this.

<!-- Please state what you've changed and how it might affect the user. -->
